### PR TITLE
Fix hash usage consistency.

### DIFF
--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -48,7 +48,7 @@ class ActiveStorage::Service::S3Service < ActiveStorage::Service
       offset = 0
 
       while offset < object.content_length
-        yield object.read(options.merge(:range => "bytes=#{offset}-#{offset + chunk_size - 1}"))
+        yield object.read(options.merge(range: "bytes=#{offset}-#{offset + chunk_size - 1}"))
         offset += chunk_size
       end
     end


### PR DESCRIPTION
Unless this was intentional, being consistent with:

https://github.com/rails/activestorage/blob/master/lib/active_storage/service/s3_service.rb#L8

Just showin' a lil' <3 while perusing the repo @dhh