### PR TITLE
Ensure S3 file integrity by sending checksum

### DIFF
--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -10,8 +10,7 @@ class ActiveStorage::Service::S3Service < ActiveStorage::Service
   end
 
   def upload(key, io, checksum: nil)
-    # FIXME: Ensure integrity by sending the checksum for service side verification
-    object_for(key).put(body: io)
+    object_for(key).put(body: io, content_md5: checksum)
   end
 
   def download(key)


### PR DESCRIPTION
S3 allows you to send a "content_md5" header that includes the base64 encoded md5 of the file. This checksum will then be used by S3 to verify that the file uploaded. It also has the added benefit that the checksum gets written to the object metadata for future use.