### PR TITLE
Fix the migration class name

### DIFF
--- a/lib/active_storage/migration.rb
+++ b/lib/active_storage/migration.rb
@@ -1,4 +1,4 @@
-class ActiveStorage::CreateTables < ActiveRecord::Migration[5.1]
+class ActiveStorageCreateTables < ActiveRecord::Migration[5.1]
   def change
     create_table :active_storage_blobs do |t|
       t.string  :key

--- a/test/database/create_users_migration.rb
+++ b/test/database/create_users_migration.rb
@@ -1,4 +1,4 @@
-class ActiveStorage::CreateUsers < ActiveRecord::Migration[5.1]
+class ActiveStorageCreateUsers < ActiveRecord::Migration[5.1]
   def change
     create_table :users do |t|
       t.string :name

--- a/test/database/setup.rb
+++ b/test/database/setup.rb
@@ -2,5 +2,5 @@ require "active_storage/migration"
 require_relative "create_users_migration"
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
-ActiveStorage::CreateTables.migrate(:up)
-ActiveStorage::CreateUsers.migrate(:up)
+ActiveStorageCreateTables.migrate(:up)
+ActiveStorageCreateUsers.migrate(:up)


### PR DESCRIPTION
Hello,

Due to Active Support auto loading feature, the migration class shouldn't be name-spaced under the `ActiveStorage` constant, otherwise, running the migrations would throw an error.

The constant name doesn't reflect the folder structure / file name but once this got integrated into Rails, this shouldn't be a problem as it will be a template under the generator files.

Have a nice day !