### PR TITLE
Add railtie support for configuring Mirror service

### DIFF
--- a/lib/active_storage/storage_services.yml
+++ b/lib/active_storage/storage_services.yml
@@ -21,7 +21,7 @@ google:
   keyfile: <%= Rails.root.join("path/to/gcs.keyfile") %>
   bucket: your_own_bucket
 
+# The first child service will be the primary that supplies files on read
 mirror:
   service: Mirror
-  primary: local
-  secondaries: [ amazon, google ]
+  child_services: [ local, amazon, google ]


### PR DESCRIPTION
Here's a crack at fixing #9 

I do not immediately see how to modify the tests to verify the correct behavior; currently there is no test coverage for the railtie. But this works fine in my sample project.

Also not entirely convinced I've nailed the naming. I did change the key in the configuration file because I'm not comfortable with "service" and "services" right next to each other - seems like an invitation to errors.