### PR TITLE
Disk storage: ensure URLs end with the blob filename

### DIFF
--- a/lib/active_storage/disk_controller.rb
+++ b/lib/active_storage/disk_controller.rb
@@ -9,8 +9,8 @@ require "active_support/core_ext/object/inclusion"
 # if you are using the +Disk+ service.
 #
 # By default, mounting the Active Storage engine inside your application will
-# define a +/rails/blobs/:encoded_key+ route that will reference this controller's
-# +show+ action and will be used to serve local files.
+# define a +/rails/blobs/:encoded_key/*filename+ route that will reference this
+# controller's +show+ action and will be used to serve local files.
 #
 # A URL for an attachment can be generated through its +#url+ method, that
 # will use the aforementioned route.

--- a/lib/active_storage/engine.rb
+++ b/lib/active_storage/engine.rb
@@ -11,7 +11,7 @@ module ActiveStorage
 
       config.after_initialize do |app|
         app.routes.prepend do
-          get "/rails/blobs/:encoded_key" => "active_storage/disk#show", as: :rails_disk_blob
+          get "/rails/blobs/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_blob
         end
       end
     end

--- a/lib/active_storage/service/disk_service.rb
+++ b/lib/active_storage/service/disk_service.rb
@@ -43,9 +43,9 @@ class ActiveStorage::Service::DiskService < ActiveStorage::Service
     verified_key_with_expiration = ActiveStorage::VerifiedKeyWithExpiration.encode(key, expires_in: expires_in)
 
     if defined?(Rails) && defined?(Rails.application)
-      Rails.application.routes.url_helpers.rails_disk_blob_path(verified_key_with_expiration, disposition: disposition)
+      Rails.application.routes.url_helpers.rails_disk_blob_path(verified_key_with_expiration, disposition: disposition, filename: filename)
     else
-      "/rails/blobs/#{verified_key_with_expiration}?disposition=#{disposition}"
+      "/rails/blobs/#{verified_key_with_expiration}/#{filename}?disposition=#{disposition}"
     end
   end
 

--- a/test/blob_test.rb
+++ b/test/blob_test.rb
@@ -23,6 +23,6 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
   private
     def expected_url_for(blob, disposition: :inline)
-      "/rails/blobs/#{ActiveStorage::VerifiedKeyWithExpiration.encode(blob.key, expires_in: 5.minutes)}?disposition=#{disposition}"
+      "/rails/blobs/#{ActiveStorage::VerifiedKeyWithExpiration.encode(blob.key, expires_in: 5.minutes)}/#{blob.filename}?disposition=#{disposition}"
     end
 end

--- a/test/disk_controller_test.rb
+++ b/test/disk_controller_test.rb
@@ -10,7 +10,7 @@ require "active_storage/verified_key_with_expiration"
 class ActiveStorage::DiskControllerTest < ActionController::TestCase
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |routes|
     routes.draw do
-      get "/rails/blobs/:encoded_key" => "active_storage/disk#show", as: :rails_disk_blob
+      get "/rails/blobs/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_blob
     end
   end
 
@@ -21,13 +21,13 @@ class ActiveStorage::DiskControllerTest < ActionController::TestCase
   end
 
   test "showing blob inline" do
-    get :show, params: { encoded_key: ActiveStorage::VerifiedKeyWithExpiration.encode(@blob.key, expires_in: 5.minutes) }
+    get :show, params: { filename: @blob.filename, encoded_key: ActiveStorage::VerifiedKeyWithExpiration.encode(@blob.key, expires_in: 5.minutes) }
     assert_equal "inline; filename=\"#{@blob.filename}\"", @response.headers["Content-Disposition"]
     assert_equal "text/plain", @response.headers["Content-Type"]
   end
 
   test "sending blob as attachment" do
-    get :show, params: { encoded_key: ActiveStorage::VerifiedKeyWithExpiration.encode(@blob.key, expires_in: 5.minutes), disposition: :attachment }
+    get :show, params: { filename: @blob.filename, encoded_key: ActiveStorage::VerifiedKeyWithExpiration.encode(@blob.key, expires_in: 5.minutes), disposition: :attachment }
     assert_equal "attachment; filename=\"#{@blob.filename}\"", @response.headers["Content-Disposition"]
     assert_equal "text/plain", @response.headers["Content-Type"]
   end


### PR DESCRIPTION
Since some user agents don't respect Content-Disposition filename, resulting in download filenames of `<giant SGID key>`.