### PR TITLE
Clarify how a service can build other composed services

### DIFF
--- a/lib/active_storage/service.rb
+++ b/lib/active_storage/service.rb
@@ -32,15 +32,24 @@
 class ActiveStorage::Service
   class ActiveStorage::IntegrityError < StandardError; end
 
+  extend ActiveSupport::Autoload
+  autoload :Configurator
+
+  # Configure an Active Storage service by name from a set of configurations,
+  # typically loaded from a YAML file. The Active Storage engine uses this
+  # to set the global Active Storage service when the app boots.
   def self.configure(service_name, configurations)
-    require 'active_storage/service/configurator'
-    Configurator.new(service_name, configurations).build
+    Configurator.build(service_name, configurations)
   end
 
   # Override in subclasses that stitch together multiple services and hence
-  # need to do additional lookups from configurations. See MirrorService.
-  def self.build(service_config, all_configurations) #:nodoc:
-    new(service_config)
+  # need to build additional services using the configurator.
+  #
+  # Passes the configurator and all of the service's config as keyword args.
+  #
+  # See MirrorService for an example.
+  def self.build(configurator:, service: nil, **service_config) #:nodoc:
+    new(**service_config)
   end
 
   def upload(key, io, checksum: nil)

--- a/lib/active_storage/service/mirror_service.rb
+++ b/lib/active_storage/service/mirror_service.rb
@@ -5,15 +5,11 @@ class ActiveStorage::Service::MirrorService < ActiveStorage::Service
 
   delegate :download, :exist?, :url, to: :primary
 
-  # Stitch together from named configuration.
-  def self.build(service_config, all_configurations) #:nodoc:
-    primary = ActiveStorage::Service.configure(service_config.fetch(:primary), all_configurations)
-
-    mirrors = service_config.fetch(:mirrors).collect do |service_name|
-      ActiveStorage::Service.configure(service_name.to_sym, all_configurations)
-    end
-
-    new primary: primary, mirrors: mirrors
+  # Stitch together from named services.
+  def self.build(primary:, mirrors:, configurator:, **options) #:nodoc:
+    new \
+      primary: configurator.build(primary),
+      mirrors: mirrors.collect { |name| configurator.build name }
   end
 
   def initialize(primary:, mirrors:)

--- a/test/service/disk_service_test.rb
+++ b/test/service/disk_service_test.rb
@@ -2,7 +2,7 @@ require "tmpdir"
 require "service/shared_service_tests"
 
 class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
-  SERVICE = ActiveStorage::Service.configure(:test, test: { service: "Disk", root: File.join(Dir.tmpdir, "active_storage") })
+  SERVICE = ActiveStorage::Service::DiskService.new(root: File.join(Dir.tmpdir, "active_storage"))
 
   include ActiveStorage::Service::SharedServiceTests
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,9 +5,8 @@ require "active_support/testing/autorun"
 require "byebug"
 
 require "active_storage"
-
-require "active_storage/service"
-ActiveStorage::Blob.service = ActiveStorage::Service.configure(:test, test: { service: 'Disk', root: File.join(Dir.tmpdir, "active_storage") })
+require "active_storage/service/disk_service"
+ActiveStorage::Blob.service = ActiveStorage::Service::DiskService.new(root: File.join(Dir.tmpdir, "active_storage"))
 
 require "active_storage/verified_key_with_expiration"
 ActiveStorage::VerifiedKeyWithExpiration.verifier = ActiveSupport::MessageVerifier.new("Testing")


### PR DESCRIPTION
* Service.build takes the literal YAML config hash for the service and a reference to the Configurator that's doing the building.
* Services that compose additional services can use the Configurator to look them up and build them by name. See MirrorService for an example.

References #23