### PR TITLE
Symbolize all keys inside configuration nested hash

### DIFF
--- a/lib/active_storage/service/configurator.rb
+++ b/lib/active_storage/service/configurator.rb
@@ -6,7 +6,7 @@ class ActiveStorage::Service::Configurator #:nodoc:
   end
 
   def initialize(configurations)
-    @configurations = configurations.symbolize_keys
+    @configurations = configurations.deep_symbolize_keys
   end
 
   def build(service_name)


### PR DESCRIPTION
Since configuration is a nested hash we need to symbolize all keys
of the hash. Otherwise fetching the service configuration will fail on start



[This is the first failure point](https://github.com/rails/activestorage/blob/master/lib/active_storage/service/configurator.rb#L14)