### PR TITLE
Add basic tests to the Configurator#build

### DIFF
--- a/test/service/configurator_test.rb
+++ b/test/service/configurator_test.rb
@@ -1,0 +1,15 @@
+require "service/shared_service_tests"
+
+class ActiveStorage::Service::ConfiguratorTest < ActiveSupport::TestCase
+  test "builds correct service instance based on service name" do
+    service = ActiveStorage::Service::Configurator.build(:s3, SERVICE_CONFIGURATIONS)
+    assert_instance_of ActiveStorage::Service::S3Service, service
+  end
+
+  test "raises error when passing non-existent service name" do
+    assert_raise RuntimeError do
+      ActiveStorage::Service::Configurator.build(:bigfoot, SERVICE_CONFIGURATIONS)
+    end
+  end
+end
+


### PR DESCRIPTION
Test the `Configurator#build method`, just basic test which asserts resolving to the correct service instance and weather framework raises error when passing the wrong service_name value

r? @dhh 
