### PR TITLE
Scope aws-skd to version 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ gem 'byebug'
 gem 'sqlite3'
 gem 'httparty'
 
-gem 'aws-sdk', require: false
+gem 'aws-sdk', '~> 2', require: false
 gem 'google-cloud-storage', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ PLATFORMS
 
 DEPENDENCIES
   activestorage!
-  aws-sdk
+  aws-sdk (~> 2)
   bundler (~> 1.15)
   byebug
   google-cloud-storage


### PR DESCRIPTION
Since we use new `aws-sdk` API(version 2), I've scoped `aws-sdk` version
so someone doesn't accidentally install wrong version during the development.