### PR TITLE
Update GCSService#url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem 'sqlite3'
 gem 'httparty'
 
 gem 'aws-sdk', '~> 2', require: false
-gem 'google-cloud-storage', require: false
+gem 'google-cloud-storage', '~> 1.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,9 +69,9 @@ GEM
     google-cloud-core (1.0.0)
       google-cloud-env (~> 1.0)
       googleauth (~> 0.5.1)
-    google-cloud-env (1.0.0)
+    google-cloud-env (1.0.1)
       faraday (~> 0.11)
-    google-cloud-storage (1.2.0)
+    google-cloud-storage (1.3.0)
       digest-crc (~> 0.4)
       google-api-client (~> 0.13.0)
       google-cloud-core (~> 1.0)
@@ -141,7 +141,7 @@ DEPENDENCIES
   aws-sdk (~> 2)
   bundler (~> 1.15)
   byebug
-  google-cloud-storage
+  google-cloud-storage (~> 1.3)
   httparty
   rake
   sqlite3

--- a/lib/active_storage/service/gcs_service.rb
+++ b/lib/active_storage/service/gcs_service.rb
@@ -44,8 +44,8 @@ class ActiveStorage::Service::GCSService < ActiveStorage::Service
 
   def url(key, expires_in:, disposition:, filename:)
     instrument :url, key do |payload|
-      generated_url = file_for(key).signed_url(expires: expires_in) + "&" +
-        { "response-content-disposition" => "#{disposition}; filename=\"#{filename}\"" }.to_query
+      query = { "response-content-disposition" => "#{disposition}; filename=\"#{filename}\"" }
+      generated_url = file_for(key).signed_url(expires: expires_in, query: query)
       
       payload[:url] = generated_url
       


### PR DESCRIPTION
 [google-cloud-storage](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage) version `1.3` has been released, which includes @georgeclaghorn's contribution in GoogleCloudPlatform/google-cloud-ruby#1574.

This PR follows up by providing the `response-content-disposition` query parameter as an argument to `Google::Cloud::Storage::File#signed_url` for inclusion in the resulting URL.

* Update [google-cloud-storage](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage) dependency to `1.3`
* Refactor URL creation, moving the query string to an argument to `Google::Cloud::Storage::File#signed_url`

This PR adds no test because the existing test [adequately covers](https://github.com/rails/activestorage/blob/master/test/service/gcs_service_test.rb#L12) the change.