### PR TITLE
Remove unnecessary variables from gcs_service implementation

### DIFF
--- a/lib/active_storage/service/gcs_service.rb
+++ b/lib/active_storage/service/gcs_service.rb
@@ -36,20 +36,14 @@ class ActiveStorage::Service::GCSService < ActiveStorage::Service
 
   def exist?(key)
     instrument :exist, key do |payload|
-      answer = file_for(key).present?
-      payload[:exist] = answer
-      answer
+      payload[:exist] = file_for(key).present?
     end
   end
 
   def url(key, expires_in:, disposition:, filename:)
     instrument :url, key do |payload|
       query = { "response-content-disposition" => "#{disposition}; filename=\"#{filename}\"" }
-      generated_url = file_for(key).signed_url(expires: expires_in, query: query)
-      
-      payload[:url] = generated_url
-      
-      generated_url
+      payload[:url] = file_for(key).signed_url(expires: expires_in, query: query)
     end
   end
 


### PR DESCRIPTION
Removing unnecessary variables inside`exist? and url` methods on `GcsService`
> Ruby assignment always returns the right-hand side; no need to use the intermediate local var.
@jeremy 
