### PR TITLE
Fix regular expression on s3 test URL generation test

### DIFF
--- a/test/service/s3_service_test.rb
+++ b/test/service/s3_service_test.rb
@@ -16,7 +16,7 @@ if SERVICE_CONFIGURATIONS[:s3]
         key  = SecureRandom.base58(24)
         data = "Something else entirely!"
         direct_upload_url = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size)
-        
+
         url   = URI.parse(direct_upload_url).to_s.split("?").first
         query = CGI::parse(URI.parse(direct_upload_url).query).collect { |(k, v)| [ k, v.first ] }.to_h
 
@@ -30,16 +30,16 @@ if SERVICE_CONFIGURATIONS[:s3]
           },
           debug_output: STDOUT
         )
-        
+
         assert_equal data, @service.download(key)
       ensure
         @service.delete key
       end
     end
-    
+
     test "signed URL generation" do
-      assert_match /rails-activestorage\.s3\.amazonaws\.com.*response-content-disposition=inline.*avatar\.png/,
-        @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png")    
+      assert_match /.+s3.+amazonaws.com.*response-content-disposition=inline.*avatar\.png/,
+        @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png")
     end
   end
 else


### PR DESCRIPTION
So tests are passing if the bucket name is `rails-activestorage`.
But developers specify their own s3 tests configuration (in my case was
`activestorage-test`) then this regex fails.

Also the first part of url is dynamic and based on bucket name and region
`https://<bucket name>.s3.<region>.amazonaws.com...`