### PR TITLE
Allow custom endpoints for S3.

### DIFF
--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -4,8 +4,24 @@ require "active_support/core_ext/numeric/bytes"
 class ActiveStorage::Service::S3Service < ActiveStorage::Service
   attr_reader :client, :bucket
 
-  def initialize(access_key_id:, secret_access_key:, region:, bucket:)
-    @client = Aws::S3::Resource.new(access_key_id: access_key_id, secret_access_key: secret_access_key, region: region)
+  def initialize(access_key_id:, secret_access_key:, region:, bucket:, endpoint: nil)
+    @client = if endpoint
+      Aws::S3::Resource.new(
+        access_key_id:     access_key_id,
+        secret_access_key: secret_access_key,
+        region:            region,
+        bucket:            bucket
+      )
+    else
+      Aws::S3::Resource.new(
+        access_key_id:     access_key_id,
+        secret_access_key: secret_access_key,
+        region:            region,
+        bucket:            bucket,
+        endpoint:          endpoint
+      )
+    end
+
     @bucket = @client.bucket(bucket)
   end
 


### PR DESCRIPTION
Since S3 is a published protocol, it doesn't necessarily follow that an Active Storage user will always want to use S3 storage against Amazon's cloud.

The Amazon SDK being used by Active Storage supports an additional endpoint parameter to enable support for hosted S3.

This change allows an optional `endpoint` parameter to be added to the config yaml i.e. the default behaviour is still to use Amazon's own cloud but it may be overridden if the user chooses to do so.