### PR TITLE
Revert back to the original implementaion with varaibles

### DIFF
--- a/lib/active_storage/service/gcs_service.rb
+++ b/lib/active_storage/service/gcs_service.rb
@@ -36,14 +36,20 @@ class ActiveStorage::Service::GCSService < ActiveStorage::Service
 
   def exist?(key)
     instrument :exist, key do |payload|
-      payload[:exist] = file_for(key).present?
+      answer = file_for(key).present?
+      payload[:exist] = answer
+      answer
     end
   end
 
   def url(key, expires_in:, disposition:, filename:)
     instrument :url, key do |payload|
       query = { "response-content-disposition" => "#{disposition}; filename=\"#{filename}\"" }
-      payload[:url] = file_for(key).signed_url(expires: expires_in, query: query)
+      generated_url = file_for(key).signed_url(expires: expires_in, query: query)
+
+      payload[:url] = generated_url
+
+      generated_url
     end
   end
 


### PR DESCRIPTION
Revert `exist? and url` to the original implementation.
Since the new one doesn't provide any benefits and makes implementation
harder to follow.

Related to [43](https://github.com/rails/activestorage/pull/43)

r? @georgeclaghorn 