### PR TITLE
Swap hard-coded S3 URL in DirectUploadsControllerTest with config hash value.

### DIFF
--- a/test/direct_uploads_controller_test.rb
+++ b/test/direct_uploads_controller_test.rb
@@ -12,7 +12,7 @@ if SERVICE_CONFIGURATIONS[:s3]
       @blob = create_blob
       @routes = Routes
       @controller = ActiveStorage::DirectUploadsController.new
-      @config = SERVICE_CONFIGURATIONS[:s3]
+      @config = SERVICE_CONFIGURATIONS
 
       @old_service = ActiveStorage::Blob.service
       ActiveStorage::Blob.service = ActiveStorage::Service.configure(:s3, SERVICE_CONFIGURATIONS)
@@ -28,7 +28,7 @@ if SERVICE_CONFIGURATIONS[:s3]
 
       details = JSON.parse(@response.body)
 
-      assert_match /#{@config[:bucket]}\.s3.(\S+)?amazonaws\.com/, details["url"]
+      assert_match /#{@config[:s3][:bucket]}\.s3.(\S+)?amazonaws\.com/, details["url"]
       assert_equal "hello.txt", GlobalID::Locator.locate_signed(details["sgid"]).filename.to_s
     end
   end

--- a/test/direct_uploads_controller_test.rb
+++ b/test/direct_uploads_controller_test.rb
@@ -12,7 +12,6 @@ if SERVICE_CONFIGURATIONS[:s3]
       @blob = create_blob
       @routes = Routes
       @controller = ActiveStorage::DirectUploadsController.new
-      @config = SERVICE_CONFIGURATIONS
 
       @old_service = ActiveStorage::Blob.service
       ActiveStorage::Blob.service = ActiveStorage::Service.configure(:s3, SERVICE_CONFIGURATIONS)
@@ -28,7 +27,7 @@ if SERVICE_CONFIGURATIONS[:s3]
 
       details = JSON.parse(@response.body)
 
-      assert_match /#{@config[:s3][:bucket]}\.s3.(\S+)?amazonaws\.com/, details["url"]
+      assert_match /#{SERVICE_CONFIGURATIONS[:s3][:bucket]}\.s3.(\S+)?amazonaws\.com/, details["url"]
       assert_equal "hello.txt", GlobalID::Locator.locate_signed(details["sgid"]).filename.to_s
     end
   end

--- a/test/direct_uploads_controller_test.rb
+++ b/test/direct_uploads_controller_test.rb
@@ -12,6 +12,7 @@ if SERVICE_CONFIGURATIONS[:s3]
       @blob = create_blob
       @routes = Routes
       @controller = ActiveStorage::DirectUploadsController.new
+      @config = SERVICE_CONFIGURATIONS[:s3]
 
       @old_service = ActiveStorage::Blob.service
       ActiveStorage::Blob.service = ActiveStorage::Service.configure(:s3, SERVICE_CONFIGURATIONS)
@@ -27,7 +28,7 @@ if SERVICE_CONFIGURATIONS[:s3]
 
       details = JSON.parse(@response.body)
 
-      assert_match /#{SERVICE_CONFIGURATIONS[:s3][:bucket]}\.s3.amazonaws\.com/, details["url"]
+      assert_match /#{@config[:bucket]}\.s3.(\S+)?amazonaws\.com/, details["url"]
       assert_equal "hello.txt", GlobalID::Locator.locate_signed(details["sgid"]).filename.to_s
     end
   end

--- a/test/direct_uploads_controller_test.rb
+++ b/test/direct_uploads_controller_test.rb
@@ -27,7 +27,7 @@ if SERVICE_CONFIGURATIONS[:s3]
 
       details = JSON.parse(@response.body)
 
-      assert_match /rails-activestorage\.s3.amazonaws\.com/, details["url"]
+      assert_match /#{SERVICE_CONFIGURATIONS[:s3][:bucket]}\.s3.amazonaws\.com/, details["url"]
       assert_equal "hello.txt", GlobalID::Locator.locate_signed(details["sgid"]).filename.to_s
     end
   end

--- a/test/service/s3_service_test.rb
+++ b/test/service/s3_service_test.rb
@@ -38,7 +38,7 @@ if SERVICE_CONFIGURATIONS[:s3]
     end
 
     test "signed URL generation" do
-      assert_match /.+s3.+amazonaws.com.*response-content-disposition=inline.*avatar\.png/,
+      assert_match /#{@config[:s3][:bucket]}\.s3.(\S+)?amazonaws.com.*response-content-disposition=inline.*avatar\.png/,
         @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png")
     end
   end

--- a/test/service/s3_service_test.rb
+++ b/test/service/s3_service_test.rb
@@ -38,7 +38,7 @@ if SERVICE_CONFIGURATIONS[:s3]
     end
 
     test "signed URL generation" do
-      assert_match /#{@config[:s3][:bucket]}\.s3.(\S+)?amazonaws.com.*response-content-disposition=inline.*avatar\.png/,
+      assert_match /#{SERVICE_CONFIGURATIONS[:s3][:bucket]}\.s3.(\S+)?amazonaws.com.*response-content-disposition=inline.*avatar\.png/,
         @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png")
     end
   end

--- a/test/service/shared_service_tests.rb
+++ b/test/service/shared_service_tests.rb
@@ -11,6 +11,7 @@ module ActiveStorage::Service::SharedServiceTests
     setup do
       @service = self.class.const_get(:SERVICE)
       @service.upload FIXTURE_KEY, StringIO.new(FIXTURE_DATA)
+      @config = SERVICE_CONFIGURATIONS
     end
 
     teardown do

--- a/test/service/shared_service_tests.rb
+++ b/test/service/shared_service_tests.rb
@@ -11,7 +11,6 @@ module ActiveStorage::Service::SharedServiceTests
     setup do
       @service = self.class.const_get(:SERVICE)
       @service.upload FIXTURE_KEY, StringIO.new(FIXTURE_DATA)
-      @config = SERVICE_CONFIGURATIONS
     end
 
     teardown do


### PR DESCRIPTION
Hi there.

I'm replacing the bucket name section of the S3 URL with the value in the configuration hash. This allows folks to configure their own S3 information in `configurations.yml` and have a passing test  when running locally.

Thank you.