### PR TITLE
Useful error messages for two possible misconfigurations

### DIFF
--- a/lib/active_storage/engine.rb
+++ b/lib/active_storage/engine.rb
@@ -56,6 +56,9 @@ module ActiveStorage
           rescue => e
             raise e, "Cannot load `Rails.config.active_storage.service`:\n#{e.message}", e.backtrace
           end
+      else
+        raise "No storage service specified for current env (#{Rails.env}). " \
+              "Add config.active_storage.service = :local into your config/environments/#{Rails.env}.rb."
       end
     end
   end

--- a/lib/active_storage/storage_services.yml
+++ b/lib/active_storage/storage_services.yml
@@ -9,8 +9,8 @@ local:
 # Use rails secrets:edit to set the AWS secrets (as shared:aws:access_key_id|secret_access_key)
 amazon:
   service: S3
-  access_key_id: <%= Rails.application.secrets.aws[:access_key_id] %>
-  secret_access_key: <%= Rails.application.secrets.aws[:secret_access_key] %>
+  access_key_id: <%= Rails.application.secrets.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= Rails.application.secrets.dig(:aws, :secret_access_key) %>
   region: us-east-1
   bucket: your_own_bucket
 


### PR DESCRIPTION
Helpful error messages for two mistakes I made while setting up. Had to read the source to understand them.

1. No AWS keys in secrets.yml, but AWS is in storage_services.yml (it's there by default) -> avoid error
2. No `config.active_storage.service` for current env -> better error message
