### PR TITLE
Fixing logger to work with Rails 5.2.0.alpha

### DIFF
--- a/lib/active_storage/log_subscriber.rb
+++ b/lib/active_storage/log_subscriber.rb
@@ -2,9 +2,9 @@ require "active_support/log_subscriber"
 
 class ActiveStorage::LogSubscriber < ActiveSupport::LogSubscriber
   def service_upload(event)
-    message = color("Uploaded file to key: #{key_in(event)}", GREEN)
-    message << color(" (checksum: #{event.payload[:checksum]})", GREEN) if event.payload[:checksum]
-    info event, message
+    message = "Uploaded file to key: #{key_in(event)}"
+    message << " (checksum: #{event.payload[:checksum]})"
+    info event, color(message, GREEN) if event.payload[:checksum]
   end
 
   def service_download(event)


### PR DESCRIPTION
Adding rails 5.2.0.alpha as a dependency causes sumthing like this error:
```
..Could not log "service_upload.active_storage" event. RuntimeError: can't modify frozen String
["/home/travis/build/rails/activestorage/lib/active_storage/log_subscriber.rb:6:in `service_upload'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/subscriber.rb:101:in `finish'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/log_subscriber.rb:84:in `finish'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/notifications/fanout.rb:104:in `finish'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/notifications/fanout.rb:48:in `block in finish'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/notifications/fanout.rb:48:in `each'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/notifications/fanout.rb:48:in `finish'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/notifications/instrumenter.rb:44:in `finish_with_state'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/notifications/instrumenter.rb:29:in `instrument'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/bundler/gems/rails-c1f9fa8c6959/activesupport/lib/active_support/notifications.rb:168:in `instrument'",
"/home/travis/build/rails/activestorage/lib/active_storage/service.rb:87:in `instrument'",
"/home/travis/build/rails/activestorage/lib/active_storage/service/disk_service.rb:14:in `upload'",
"/home/travis/build/rails/activestorage/lib/active_storage/blob.rb:56:in `upload'",
"/home/travis/build/rails/activestorage/lib/active_storage/blob.rb:21:in `block in build_after_upload'",
"/home/travis/build/rails/activestorage/lib/active_storage/blob.rb:16:in `tap'",
"/home/travis/build/rails/activestorage/lib/active_storage/blob.rb:16:in `build_after_upload'",
"/home/travis/build/rails/activestorage/lib/active_storage/blob.rb:26:in `create_after_upload!'",
"/home/travis/build/rails/activestorage/test/test_helper.rb:30:in `create_blob'",
"/home/travis/build/rails/activestorage/test/blob_test.rb:8:in `block in <class:BlobTest>'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest/test.rb:107:in `block (3 levels) in run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest/test.rb:204:in `capture_exceptions'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest/test.rb:104:in `block (2 levels) in run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest/test.rb:255:in `time_it'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest/test.rb:103:in `block in run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:350:in `on_signal'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest/test.rb:275:in `with_info_handler'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest/test.rb:102:in `run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:830:in `run_one_method'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:324:in `run_one_method'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:311:in `block (2 levels) in run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:310:in `each'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:310:in `block in run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:350:in `on_signal'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:337:in `with_info_handler'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:309:in `run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:159:in `block in __run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:159:in `map'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:159:in `__run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:136:in `run'",
"/home/travis/build/rails/activestorage/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:63:in `block in autorun'"]
```
Probably, because, `color` freezes the string.