### PR TITLE
[WIP] Implement downsampling (size: arg)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem "byebug"
 gem "sqlite3"
 gem "httparty"
 
+gem "mini_magick"
+
 gem "aws-sdk", "~> 2", require: false
 gem "google-cloud-storage", "~> 1.3", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: c1f9fa8c69590222fac43d58bf64ef4a1225d7ce
+  revision: 5153c0c21daa2f19b01e8ed2738e9f154bd948f7
   specs:
     actionpack (5.2.0.alpha)
       actionview (= 5.2.0.alpha)
@@ -38,6 +38,7 @@ PATH
       activejob (>= 5.2.0.alpha)
       activerecord (>= 5.2.0.alpha)
       activesupport (>= 5.2.0.alpha)
+      mini_magick
 
 GEM
   remote: https://rubygems.org/
@@ -46,14 +47,14 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
     ast (2.3.0)
-    aws-sdk (2.10.7)
-      aws-sdk-resources (= 2.10.7)
-    aws-sdk-core (2.10.7)
+    aws-sdk (2.10.12)
+      aws-sdk-resources (= 2.10.12)
+    aws-sdk-core (2.10.12)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.7)
-      aws-sdk-core (= 2.10.7)
-    aws-sigv4 (1.0.0)
+    aws-sdk-resources (2.10.12)
+      aws-sdk-core (= 2.10.12)
+    aws-sigv4 (1.0.1)
     builder (3.2.3)
     byebug (9.0.6)
     concurrent-ruby (1.0.5)
@@ -65,7 +66,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    google-api-client (0.13.0)
+    google-api-client (0.13.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.5)
       httpclient (>= 2.8.1, < 3.0)
@@ -105,6 +106,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_magick (4.8.0)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     multi_json (1.12.1)
@@ -168,6 +170,7 @@ DEPENDENCIES
   byebug
   google-cloud-storage (~> 1.3)
   httparty
+  mini_magick
   rake
   rubocop
   sqlite3

--- a/activestorage.gemspec
+++ b/activestorage.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack", ">= 5.2.0.alpha"
   s.add_dependency "activejob", ">= 5.2.0.alpha"
 
+  s.add_dependency "mini_magick"
+
   s.add_development_dependency "bundler", "~> 1.15"
 
   s.files      = `git ls-files`.split("\n")

--- a/lib/active_storage/blob.rb
+++ b/lib/active_storage/blob.rb
@@ -40,8 +40,8 @@ class ActiveStorage::Blob < ActiveRecord::Base
     ActiveStorage::Filename.new(self[:filename])
   end
 
-  def url(expires_in: 5.minutes, disposition: :inline)
-    service.url key, expires_in: expires_in, disposition: disposition, filename: filename
+  def url(expires_in: 5.minutes, disposition: :inline, size: nil)
+    service.thumbnail_url key, size: size, expires_in: expires_in, disposition: disposition, filename: filename
   end
 
   def url_for_direct_upload(expires_in: 5.minutes)

--- a/lib/active_storage/service.rb
+++ b/lib/active_storage/service.rb
@@ -61,13 +61,13 @@ class ActiveStorage::Service
 
   def thumbnail_url(key, size: nil, **url_options)
     thumbnail_key = key + (size || '')
-    if exist? thumbnail_key
-      url(thumbnail_key, **url_options)
-    else
-      fullsize_image = download key
-      upload thumbnail_key, downsampled(fullsize_image, size)
-      url(thumbnail_key, **url_options)
-    end
+    generate_thumbnail(key, size, thumbnail_key) unless exist? thumbnail_key
+    url(thumbnail_key, **url_options)
+  end
+
+  def generate_thumbnail(key, size)
+    fullsize_image = download key
+    upload thumbnail_key, downsampled(fullsize_image, size)
   end
 
   def downsampled(image_data, size)

--- a/lib/active_storage/service.rb
+++ b/lib/active_storage/service.rb
@@ -58,6 +58,26 @@ class ActiveStorage::Service
     end
   end
 
+
+  def thumbnail_url(key, size: nil, **url_options)
+    thumbnail_key = key + (size || '')
+    if exist? thumbnail_key
+      url(thumbnail_key, **url_options)
+    else
+      fullsize_image = download key
+      upload thumbnail_key, downsampled(fullsize_image, size)
+      url(thumbnail_key, **url_options)
+    end
+  end
+
+  def downsampled(image_data, size)
+    require 'mini_magick'
+    image = MiniMagick::Image.read(image_data)
+    image.resize size
+    File.open(image.path)
+  end
+
+
   def upload(key, io, checksum: nil)
     raise NotImplementedError
   end

--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -61,8 +61,9 @@ class ActiveStorage::Service::S3Service < ActiveStorage::Service
 
   def url(key, expires_in:, disposition:, filename:)
     instrument :url, key do |payload|
+      safe_filename = ActiveSupport::Inflector.transliterate(filename.to_s)
       generated_url = object_for(key).presigned_url :get, expires_in: expires_in,
-        response_content_disposition: "#{disposition}; filename=\"#{filename}\""
+        response_content_disposition: "#{disposition}; filename=\"#{safe_filename}\""
 
       payload[:url] = generated_url
 

--- a/test/blob_test.rb
+++ b/test/blob_test.rb
@@ -34,6 +34,13 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "url with downsampling" do
+    blob = create_blob data: ActiveStorage::Service::SharedServiceTests::FIXTURE_DATA
+    assert_nothing_raised do
+      blob.url(size: '10x10')
+    end
+  end
+
   private
     def expected_url_for(blob, disposition: :inline)
       "/rails/active_storage/disk/#{ActiveStorage::VerifiedKeyWithExpiration.encode(blob.key, expires_in: 5.minutes)}/#{blob.filename}?disposition=#{disposition}"


### PR DESCRIPTION
ActiveStorage is, unfortunately, almost useless to me without the ability to downsample images on-the-fly. And `size:` arg was already there, which means I'm not the only one who thought about this.

- **Caching:** generated thumbnails are saved back into the service and later re-used. This is implemented in terms of the existing`Service` interface, no new support from services needed.
- **Performance:** first request for a thumbnail returns the full-size version, but kicks off `GenerateThumbnailJob`. Once the thumbnail is ready, it starts to be served instead.

Todo:
- [ ] move the thumbnail generation into `GenerateThumbnailJob`
- [ ] figure out what to do with DiskService (DiskController expects every key to have a corresponding blob, which thumbnails don't)
- [ ] write a proper test