### PR TITLE
Add direct upload support to GCS service

### DIFF
--- a/lib/active_storage/service/gcs_service.rb
+++ b/lib/active_storage/service/gcs_service.rb
@@ -53,6 +53,17 @@ class ActiveStorage::Service::GCSService < ActiveStorage::Service
     end
   end
 
+  def url_for_direct_upload(key, expires_in:, content_type:, content_length:)
+    instrument :url, key do |payload|
+      generated_url = bucket.signed_url key, method: "PUT", expires: expires_in,
+        content_type: content_type
+
+      payload[:url] = generated_url
+
+      generated_url
+    end
+  end
+
   private
     def file_for(key)
       bucket.file(key)

--- a/test/direct_uploads_controller_test.rb
+++ b/test/direct_uploads_controller_test.rb
@@ -7,7 +7,7 @@ require "action_controller/test_case"
 require "active_storage/direct_uploads_controller"
 
 if SERVICE_CONFIGURATIONS[:s3]
-  class ActiveStorage::DirectUploadsControllerTest < ActionController::TestCase
+  class ActiveStorage::S3DirectUploadsControllerTest < ActionController::TestCase
     setup do
       @blob = create_blob
       @routes = Routes
@@ -32,5 +32,35 @@ if SERVICE_CONFIGURATIONS[:s3]
     end
   end
 else
-  puts "Skipping Direct Upload tests because no S3 configuration was supplied"
+  puts "Skipping S3 Direct Upload tests because no S3 configuration was supplied"
+end
+
+if SERVICE_CONFIGURATIONS[:gcs]
+  class ActiveStorage::GCSDirectUploadsControllerTest < ActionController::TestCase
+    setup do
+      @blob = create_blob
+      @routes = Routes
+      @controller = ActiveStorage::DirectUploadsController.new
+      @config = SERVICE_CONFIGURATIONS[:gcs]
+
+      @old_service = ActiveStorage::Blob.service
+      ActiveStorage::Blob.service = ActiveStorage::Service.configure(:gcs, SERVICE_CONFIGURATIONS)
+    end
+
+    teardown do
+      ActiveStorage::Blob.service = @old_service
+    end
+
+    test "creating new direct upload" do
+      post :create, params: { blob: {
+          filename: "hello.txt", byte_size: 6, checksum: Digest::MD5.base64digest("Hello"), content_type: "text/plain" } }
+
+      details = JSON.parse(@response.body)
+
+      assert_match %r{storage\.googleapis\.com/#{@config[:bucket]}}, details["url"]
+      assert_equal "hello.txt", GlobalID::Locator.locate_signed(details["sgid"]).filename.to_s
+    end
+  end
+else
+  puts "Skipping GCS Direct Upload tests because no GCS configuration was supplied"
 end

--- a/test/service/gcs_service_test.rb
+++ b/test/service/gcs_service_test.rb
@@ -1,10 +1,26 @@
 require "service/shared_service_tests"
+require "net/http"
+require "uri"
 
 if SERVICE_CONFIGURATIONS[:gcs]
   class ActiveStorage::Service::GCSServiceTest < ActiveSupport::TestCase
     SERVICE = ActiveStorage::Service.configure(:gcs, SERVICE_CONFIGURATIONS)
 
     include ActiveStorage::Service::SharedServiceTests
+
+    test "direct upload" do
+      begin
+        key = SecureRandom.base58(24)
+        data = "Something else entirely!"
+        direct_upload_url = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size)
+
+        write_to_url(data, direct_upload_url)
+
+        assert_equal data, @service.download(key)
+      ensure
+        @service.delete key
+      end
+    end
 
     test "signed URL generation" do
       travel_to Time.now do
@@ -13,6 +29,23 @@ if SERVICE_CONFIGURATIONS[:gcs]
 
         assert_equal url, @service.url(FIXTURE_KEY, expires_in: 2.minutes, disposition: :inline, filename: "test.txt")
       end
+    end
+
+    def write_to_url(data, url)
+      url = URI(url)
+
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+      request = Net::HTTP::Put.new(url)
+      request["content-type"] = "text/plain"
+      request["origin"] = "http://localhost:3000"
+      request["cache-control"] = "no-cache"
+      request.body = data
+
+      response = http.request(request)
+      puts response.read_body
     end
   end
 else

--- a/test/service/gcs_service_test.rb
+++ b/test/service/gcs_service_test.rb
@@ -44,8 +44,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       request["cache-control"] = "no-cache"
       request.body = data
 
-      response = http.request(request)
-      puts response.read_body
+      http.request(request)
     end
   end
 else


### PR DESCRIPTION
Google Cloud Storage does not ask you to (or allow?) specify the content
length up front, so that parameter is ignored right now. Otherwise, the
functionality is similar to the S3 service's direct upload capability.

The integration test for uploading the written URL was failing similarly
to David's S3 test when using HTTParty. Dropping down to use Net::HTTP
allows the test to complete successfully by writing and then downloading
the resulting file.

Closes #30