### PR TITLE
Add S3 upload options (server_side_encryption)

### DIFF
--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -2,18 +2,19 @@ require "aws-sdk"
 require "active_support/core_ext/numeric/bytes"
 
 class ActiveStorage::Service::S3Service < ActiveStorage::Service
-  attr_reader :client, :bucket
+  attr_reader :client, :bucket, :upload_options
 
-  def initialize(access_key_id:, secret_access_key:, region:, bucket:, **options)
-    @upload_options = options.delete(:upload_options) || {}
-    @client         = Aws::S3::Resource.new(access_key_id: access_key_id, secret_access_key: secret_access_key, region: region, **options)
-    @bucket         = @client.bucket(bucket)
+  def initialize(access_key_id:, secret_access_key:, region:, bucket:, upload: {}, **options)
+    @client = Aws::S3::Resource.new(access_key_id: access_key_id, secret_access_key: secret_access_key, region: region, **options)
+    @bucket = @client.bucket(bucket)
+
+    @upload_options = upload
   end
 
   def upload(key, io, checksum: nil)
     instrument :upload, key, checksum: checksum do
       begin
-        object_for(key).put(@upload_options.merge({ body: io, content_md5: checksum }))
+        object_for(key).put(@upload_options.merge(body: io, content_md5: checksum))
       rescue Aws::S3::Errors::BadDigest
         raise ActiveStorage::IntegrityError
       end

--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -14,7 +14,7 @@ class ActiveStorage::Service::S3Service < ActiveStorage::Service
   def upload(key, io, checksum: nil)
     instrument :upload, key, checksum: checksum do
       begin
-        object_for(key).put(@upload_options.merge(body: io, content_md5: checksum))
+        object_for(key).put(upload_options.merge(body: io, content_md5: checksum))
       rescue Aws::S3::Errors::BadDigest
         raise ActiveStorage::IntegrityError
       end

--- a/test/service/s3_service_test.rb
+++ b/test/service/s3_service_test.rb
@@ -31,7 +31,7 @@ if SERVICE_CONFIGURATIONS[:s3]
         @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png")
     end
 
-    test "encrypt file with server_side_encryption upload option" do
+    test "uploading with server-side encryption" do
       config      = {}
       config[:s3] = SERVICE_CONFIGURATIONS[:s3].merge \
         upload: { server_side_encryption: "AES256" }

--- a/test/service/s3_service_test.rb
+++ b/test/service/s3_service_test.rb
@@ -30,6 +30,20 @@ if SERVICE_CONFIGURATIONS[:s3]
       assert_match /#{SERVICE_CONFIGURATIONS[:s3][:bucket]}\.s3.(\S+)?amazonaws.com.*response-content-disposition=inline.*avatar\.png/,
         @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png")
     end
+
+    test "encrypt file with server_side_encryption upload option" do
+      skip "server_side_encryption option not supplied " unless @service.upload_options[:server_side_encryption]
+
+      begin
+        key  = SecureRandom.base58(24)
+        data = "Something else entirely!"
+        response = @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data))
+
+        assert_equal @service.upload_options[:server_side_encryption], response.server_side_encryption
+      ensure
+        @service.delete key
+      end
+    end
   end
 else
   puts "Skipping S3 Service tests because no S3 configuration was supplied"


### PR DESCRIPTION
Adds the ability to supply options such server_side_encryption for S3 upload vi an upload_options parameter in storage_services.yml. upload_options are deleted from the **options parameter because server_side_encryption can not be passed into Aws::S3::Resource.new

```
upload_options:
    server_side_encryption: 'AES256'

```

Due to the fact that gcs encrypts uploads by default, I did not feel it was worth making this something that could be set on a per model basis. 

Thanks!

 