### PR TITLE
Amazon S3: non-English filenames

### DIFF
--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -61,8 +61,9 @@ class ActiveStorage::Service::S3Service < ActiveStorage::Service
 
   def url(key, expires_in:, disposition:, filename:)
     instrument :url, key do |payload|
+      safe_filename = ActiveSupport::Inflector.transliterate(filename.to_s)
       generated_url = object_for(key).presigned_url :get, expires_in: expires_in,
-        response_content_disposition: "#{disposition}; filename=\"#{filename}\""
+        response_content_disposition: "#{disposition}; filename=\"#{safe_filename}\""
 
       payload[:url] = generated_url
 


### PR DESCRIPTION
`S3Service` seems to have a problem with non-English filenames like `фотография.jpg`. Upload goes fine, but when serving the generated url returns 400 error.

This is my crude fix: transliterate the filename right before putting it into url.

I didn't test the other services, they might have the problem too.