### PR TITLE
Fix RuboCop offenses and warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,85 @@ AllCops:
     - '**/vendor/**/*'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
 
+# Align `when` with `case`.
+Layout/CaseIndentation:
+  Enabled: true
+
+# Align comments with method definitions.
+Layout/CommentIndentation:
+  Enabled: true
+
+# No extra empty lines.
+Layout/EmptyLines:
+  Enabled: false
+
+# In a regular class definition, no empty lines around the body.
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+
+# In a regular method definition, no empty lines around the body.
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+# In a regular module definition, no empty lines around the body.
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+# Method definitions after `private` or `protected` isolated calls need one
+# extra level of indentation.
+Layout/IndentationConsistency:
+  Enabled: true
+  EnforcedStyle: rails
+
+# Two spaces, no tabs (for indentation).
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+    Enabled: true
+
+# Use `foo {}` not `foo{}`.
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
+# Use `foo { bar }` not `foo {bar}`.
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+# Use `{ a: 1 }` not `{a:1}`.
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+# Detect hard tabs, no hard tabs.
+Layout/Tab:
+  Enabled: true
+
+# Blank lines should not have any spaces.
+Layout/TrailingBlankLines:
+  Enabled: true
+
+# No trailing whitespace.
+Layout/TrailingWhitespace:
+  Enabled: true
+
 # Prefer &&/|| over and/or.
 Style/AndOr:
   Enabled: true
@@ -18,97 +97,18 @@ Style/BracesAroundHashParameters:
   Enabled: true
   EnforcedStyle: context_dependent
 
-# Align `when` with `case`.
-Style/CaseIndentation:
-  Enabled: true
-
-# Align comments with method definitions.
-Style/CommentIndentation:
-  Enabled: true
-
-# No extra empty lines.
-Style/EmptyLines:
-  Enabled: false
-
-# In a regular class definition, no empty lines around the body.
-Style/EmptyLinesAroundClassBody:
-  Enabled: true
-
-# In a regular method definition, no empty lines around the body.
-Style/EmptyLinesAroundMethodBody:
-  Enabled: true
-
-# In a regular module definition, no empty lines around the body.
-Style/EmptyLinesAroundModuleBody:
-  Enabled: true
-
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
 Style/HashSyntax:
   Enabled: true
 
-# Method definitions after `private` or `protected` isolated calls need one
-# extra level of indentation.
-Style/IndentationConsistency:
-  Enabled: true
-  EnforcedStyle: rails
-
-# Two spaces, no tabs (for indentation).
-Style/IndentationWidth:
-  Enabled: true
-
-Style/SpaceAfterColon:
-  Enabled: true
-
-Style/SpaceAfterComma:
-  Enabled: true
-
-Style/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
-
-Style/SpaceAroundKeyword:
-  Enabled: true
-
-Style/SpaceAroundOperators:
-  Enabled: true
-
-Style/SpaceBeforeFirstArg:
-    Enabled: true
-
 # Defining a method with parameters needs parentheses.
 Style/MethodDefParentheses:
-  Enabled: true
-
-# Use `foo {}` not `foo{}`.
-Style/SpaceBeforeBlockBraces:
-  Enabled: true
-
-# Use `foo { bar }` not `foo {bar}`.
-Style/SpaceInsideBlockBraces:
-  Enabled: true
-
-# Use `{ a: 1 }` not `{a:1}`.
-Style/SpaceInsideHashLiteralBraces:
-  Enabled: true
-
-Style/SpaceInsideParens:
   Enabled: true
 
 # Check quotes usage according to lint rule below.
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
-
-# Detect hard tabs, no hard tabs.
-Style/Tab:
-  Enabled: true
-
-# Blank lines should not have any spaces.
-Style/TrailingBlankLines:
-  Enabled: true
-
-# No trailing whitespace.
-Style/TrailingWhitespace:
-  Enabled: true
 
 # Use quotes for string literals when they are enough.
 Style/UnneededPercentQ:

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,6 @@ gem "httparty"
 gem "aws-sdk", "~> 2", require: false
 gem "google-cloud-storage", "~> 1.3", require: false
 
-gem 'mini_magick'
+gem "mini_magick"
 
 gem "rubocop", require: false

--- a/app/controllers/active_storage/variants_controller.rb
+++ b/app/controllers/active_storage/variants_controller.rb
@@ -20,6 +20,6 @@ class ActiveStorage::VariantsController < ActionController::Base
     end
 
     def disposition_param
-      params[:disposition].presence_in(%w( inline attachment )) || 'inline'
+      params[:disposition].presence_in(%w( inline attachment )) || "inline"
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
     route_for(:rails_blob_variation, encoded_blob_key, variation_key, filename)
   end
 
-  resolve('ActiveStorage::Variant') { |variant| route_for(:rails_variant, variant) }
+  resolve("ActiveStorage::Variant") { |variant| route_for(:rails_variant, variant) }
 end

--- a/lib/active_storage/engine.rb
+++ b/lib/active_storage/engine.rb
@@ -29,7 +29,7 @@ module ActiveStorage
       config.after_initialize do |app|
         ActiveStorage::VerifiedKeyWithExpiration.verifier = \
         ActiveStorage::Variation.verifier = \
-          Rails.application.message_verifier('ActiveStorage')
+          Rails.application.message_verifier("ActiveStorage")
       end
     end
 

--- a/lib/active_storage/variation.rb
+++ b/lib/active_storage/variation.rb
@@ -15,7 +15,7 @@ class ActiveStorage::Variation
     def decode(key)
       new verifier.verify(key)
     end
-    
+
     def encode(transformations)
       verifier.generate(transformations)
     end

--- a/test/variant_test.rb
+++ b/test/variant_test.rb
@@ -10,14 +10,14 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "resized variation" do
     variant = @blob.variant(resize: "100x100").processed
 
-    assert_match /racecar.jpg/, variant.url    
-    assert_same_image "racecar-100x100.jpg", variant    
+    assert_match /racecar.jpg/, variant.url
+    assert_same_image "racecar-100x100.jpg", variant
   end
 
   test "resized and monochrome variation" do
     variant = @blob.variant(resize: "100x100", monochrome: true).processed
 
     assert_match /racecar.jpg/, variant.url
-    assert_same_image "racecar-100x100-monochrome.jpg", variant    
+    assert_same_image "racecar-100x100-monochrome.jpg", variant
   end
 end


### PR DESCRIPTION
### Summary

This PR fixes the following offenses and warnings.

```console
% bundle exec rubocop
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/CaseIndentation has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/CommentIndentation has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/EmptyLines has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/EmptyLinesAroundClassBody has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/EmptyLinesAroundMethodBody has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/EmptyLinesAroundModuleBody has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/IndentationConsistency has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/IndentationWidth has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceAfterColon has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceAfterComma has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceAroundEqualsInParameterDefault has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceAroundKeyword has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceAroundOperators has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceBeforeFirstArg has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceBeforeBlockBraces has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceInsideBlockBraces has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceInsideHashLiteralBraces has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/SpaceInsideParens has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/Tab has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/TrailingBlankLines has the wrong namespace - should be Layout
/Users/koic/src/github.com/rails/activestorage/.rubocop.yml: Style/TrailingWhitespace has the wrong namespace - should be Layout
Inspecting 47 files
.C...CC.......C...........C..................C.

Offenses:

Gemfile:21:5: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
gem 'mini_magick'
    ^^^^^^^^^^^^^
app/controllers/active_storage/variants_controller.rb:23:68: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
      params[:disposition].presence_in(%w( inline attachment )) || 'inline'
                                                                   ^^^^^^^^
config/routes.rb:15:11: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  resolve('ActiveStorage::Variant') { |variant| route_for(:rails_variant, variant) }
          ^^^^^^^^^^^^^^^^^^^^^^^^
lib/active_storage/engine.rb:32:46: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
          Rails.application.message_verifier('ActiveStorage')
                                             ^^^^^^^^^^^^^^^
lib/active_storage/variation.rb:18:1: C: Trailing whitespace detected.
test/variant_test.rb:13:44: C: Trailing whitespace detected.
    assert_match /racecar.jpg/, variant.url
                                           ^^^^
test/variant_test.rb:14:53: C: Trailing whitespace detected.
    assert_same_image "racecar-100x100.jpg", variant
                                                    ^^^^
test/variant_test.rb:21:64: C: Trailing whitespace detected.
    assert_same_image "racecar-100x100-monochrome.jpg", variant
                                                               ^^^^

47 files inspected, 8 offenses detected
```

First, This PR fixes offences using autocorrect (`rubocop -a`) . Next, change some Cop's department from `Style` to `Layout.` 

### Other Information

Some Cop's department have changed in RuboCop 0.49.0.

https://github.com/bbatsov/rubocop/commit/54166bf76ba76b14f1bbc8a34165f175dbc3f227
