### PR TITLE
This is a engine so rails must be defined

### DIFF
--- a/lib/active_storage.rb
+++ b/lib/active_storage.rb
@@ -1,5 +1,5 @@
 require "active_record"
-require "active_storage/engine" if defined?(Rails)
+require "active_storage/engine"
 
 module ActiveStorage
   extend ActiveSupport::Autoload


### PR DESCRIPTION
This is a engine so we don't need to check weather `rails` is defined.