### PR TITLE
Compare images by MiniMagik.signature instead of byte-matching

### DIFF
--- a/test/controllers/variants_controller_test.rb
+++ b/test/controllers/variants_controller_test.rb
@@ -12,14 +12,12 @@ class ActiveStorage::VariantsControllerTest < ActionController::TestCase
   end
 
   test "showing variant inline" do
-    skip
-
     get :show, params: {
       filename: @blob.filename,
       signed_blob_id: @blob.signed_id,
       variation_key: ActiveStorage::Variation.encode(resize: "100x100") }
 
     assert_redirected_to /racecar.jpg\?disposition=inline/
-    assert_same_image "racecar-100x100.jpg", @blob.variant(resize: "100x100")
+    assert_equal_image_dimensions "racecar-100x100.jpg", @blob.variant(resize: "100x100")
   end
 end

--- a/test/models/variant_test.rb
+++ b/test/models/variant_test.rb
@@ -7,20 +7,17 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   end
 
   test "resized variation" do
-    skip
-
     variant = @blob.variant(resize: "100x100").processed
 
     assert_match /racecar.jpg/, variant.service_url
-    assert_same_image "racecar-100x100.jpg", variant
+    assert_equal_image_dimensions "racecar-100x100.jpg", variant
   end
 
   test "resized and monochrome variation" do
-    skip
-
     variant = @blob.variant(resize: "100x100", monochrome: true).processed
 
     assert_match /racecar.jpg/, variant.service_url
-    assert_same_image "racecar-100x100-monochrome.jpg", variant
+    assert_equal_image_dimensions "racecar-100x100-monochrome.jpg", variant
+    assert_equal_image_colorspace "racecar-100x100-monochrome.jpg", variant
   end
 end


### PR DESCRIPTION
#72: ~~`#signature` may miss small discrepancies (e.g. image width 200 instead of 100), but gross mistakes it catches (e.g. image width 500 instead of 100 or it not being monochrome)~~
`#signature` catches even the slightest discrepancies.